### PR TITLE
Fix CORS issues when running frontend locally

### DIFF
--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,12 @@ const { AnswerRequest, AnswerResponse, Question } = require('./types');
 
 const sessionStrikes: Record<string, number> = {};
 
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+};
+
 function getRandomQuestion(category: string): any {
   const filtered = questions.filter((q: any) => q.category === category);
   return filtered[Math.floor(Math.random() * filtered.length)];
@@ -16,6 +22,7 @@ function sendJson(res: any, data: unknown, status = 200) {
   res.writeHead(status, {
     'Content-Type': 'application/json',
     'Content-Length': Buffer.byteLength(body),
+    ...corsHeaders,
   });
   res.end(body);
 }
@@ -64,6 +71,11 @@ function handleCheckAnswer(req: any, res: any) {
 
 const server = http.createServer((req: any, res: any) => {
   const url = parse(req.url || '');
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, corsHeaders);
+    res.end();
+    return;
+  }
   if (req.method === 'GET' && url.pathname === '/questions') {
     handleGetQuestions(req, res);
   } else if (req.method === 'POST' && url.pathname === '/check-answer') {


### PR DESCRIPTION
## Summary
- allow CORS requests in the backend server
- handle preflight OPTIONS requests

## Testing
- `npm test --prefix backend`
- `npm run build --prefix frontend` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6883a5eaa6408329af8834bc8c989195