### PR TITLE
Update frontend fetch urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ cd frontend
 npm run build
 ```
 
-Open `frontend/index.html` in a browser to play the game. It fetches questions
-from the backend and renders the map using Leaflet.
+Start the backend with `npm start` so it listens on `http://localhost:3000`.
+After building the frontend, open `frontend/index.html` directly in a browser.
+The app fetches questions from `http://localhost:3000` and renders the map
+using Leaflet.
 

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -22,7 +22,7 @@ export default function GameScreen({ mode, onFinish }: Props) {
   const [gameTime, setGameTime] = useState(mode === 'sprint' ? 120 : 0);
 
   const fetchQuestion = () => {
-    fetch('/questions?category=landmark')
+    fetch('http://localhost:3000/questions?category=landmark')
       .then(r => r.json())
       .then((q: Question) => {
         setQuestion(q);
@@ -66,7 +66,7 @@ export default function GameScreen({ mode, onFinish }: Props) {
     if (!question || result) return;
 
     setClicked([lat, lng]);
-    fetch('/check-answer', {
+    fetch('http://localhost:3000/check-answer', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Summary
- update frontend GameScreen fetch URLs to use localhost
- clarify README with instructions to start backend and load the page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883ada1615c832998de854c9e8bdbfb