### PR TITLE
Add Vite bundler and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,36 @@ cd backend
 npm test
 ```
 
+Build and start the server with:
+
+```bash
+cd backend
+npm run build && npm start
+```
+
 ## Frontend
 
-The frontend React code lives in `frontend`. Build the TypeScript with:
+The frontend React code lives in `frontend` and uses Vite for bundling.
+For development run the dev server with:
+
+```bash
+cd frontend
+npm run dev
+```
+
+Create a production bundle with:
 
 ```bash
 cd frontend
 npm run build
 ```
 
-Start the backend with `npm start` so it listens on `http://localhost:3000`.
-After building the frontend, open `frontend/index.html` directly in a browser.
-The app fetches questions from `http://localhost:3000` and renders the map
+Preview the built files with:
+
+```bash
+npm run preview
+```
+Make sure the backend is running on `http://localhost:3000` before loading the
+frontend. The application fetches questions from the backend and renders the map
 using Leaflet.
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,6 @@
 </head>
 <body>
   <div id="root"></div>
-  <script type="module" src="./src/main.tsx"></script>
+  <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "tsc -p tsconfig.json",
-    "start": "echo 'open index.html in a browser'"
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^18.2.0",
@@ -16,7 +17,8 @@
     "typescript": "^5.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "@types/leaflet": "^1.9.0"
-
+    "@types/leaflet": "^1.9.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure Vite in `frontend/package.json`
- point `index.html` script tag at the Vite entry file
- document how to run backend and frontend using Vite in README

## Testing
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6883b109ec6c8329965b1fd7eb672990