### PR TITLE
Add bounce animation after map guess

### DIFF
--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,5 +1,7 @@
 import { MapContainer, TileLayer, Marker, Polyline, useMapEvents } from 'react-leaflet';
 import { LatLngTuple, LeafletMouseEvent } from 'leaflet';
+import L from 'leaflet';
+import { useEffect, useRef } from 'react';
 
 
 interface ClickHandlerProps {
@@ -20,9 +22,28 @@ export interface MapProps {
   correctPoint?: LatLngTuple;
   clickedPoint?: LatLngTuple;
   lineColor?: string;
+  answerCorrect?: boolean;
 }
 
-export default function GameMap({ onMapClick, correctPoint, clickedPoint, lineColor = 'blue' }: MapProps) {
+export default function GameMap({
+  onMapClick,
+  correctPoint,
+  clickedPoint,
+  lineColor = 'blue',
+  answerCorrect,
+}: MapProps) {
+  const clickedRef = useRef<L.Marker>(null);
+
+  useEffect(() => {
+    if (!clickedRef.current || clickedPoint === undefined) return;
+    const el = clickedRef.current.getElement();
+    if (!el) return;
+    const cls = answerCorrect ? 'marker-bounce-correct' : 'marker-bounce-wrong';
+    el.classList.add(cls);
+    const remove = () => el.classList.remove(cls);
+    el.addEventListener('animationend', remove, { once: true });
+  }, [clickedPoint, answerCorrect]);
+
   return (
     <MapContainer center={[20, 0]} zoom={2} style={{ height: '100%', width: '100%' }}>
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
@@ -31,7 +52,7 @@ export default function GameMap({ onMapClick, correctPoint, clickedPoint, lineCo
       {correctPoint && clickedPoint && (
         <>
           <Marker position={correctPoint} />
-          <Marker position={clickedPoint} />
+          <Marker ref={clickedRef} position={clickedPoint} />
           <Polyline pathOptions={{ color: lineColor }} positions={[clickedPoint, correctPoint]} />
 
         </>

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -115,6 +115,7 @@ export default function GameScreen({ mode, onFinish }: Props) {
           correctPoint={result ? [result.correctLat, result.correctLng] : undefined}
           clickedPoint={clicked ? [clicked[0], clicked[1]] : undefined}
           lineColor={result ? (result.distanceKm <= 50 ? 'green' : result.distanceKm <= 200 ? 'yellow' : 'red') : 'blue'}
+          answerCorrect={result ? result.correct : undefined}
         />
         {result && <ResultOverlay correct={result.correct} distance={result.distanceKm} />}
       </div>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -71,3 +71,51 @@ button:hover {
   padding: 0.5rem;
 }
 
+/* marker animations */
+@keyframes bounce {
+  0% {
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(-15px);
+  }
+  60% {
+    transform: translateY(0);
+  }
+  80% {
+    transform: translateY(-7px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes shake {
+  0% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-5px);
+  }
+  40% {
+    transform: translateX(5px);
+  }
+  60% {
+    transform: translateX(-5px);
+  }
+  80% {
+    transform: translateX(5px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+.marker-bounce-correct {
+  animation: bounce 0.6s ease-out;
+}
+
+.marker-bounce-wrong {
+  animation: shake 0.5s ease-out;
+}
+


### PR DESCRIPTION
## Summary
- animate clicked marker for correct or wrong answers
- pass new answerCorrect prop to `GameMap`
- define CSS keyframes for bounce and shake

## Testing
- `npm test` in `backend` *(passes)*
- `npm run build` in `frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b65c161c8329bec89440ad4ff5e7