### PR TITLE
Add stats modal with continue or home

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,10 @@ export default function App() {
     setMode('end');
   };
 
+  const handleHome = () => {
+    setMode('start');
+  };
+
   const handleRestart = () => {
     setScore(0);
     setMode('start');
@@ -23,6 +27,6 @@ export default function App() {
 
   if (mode === 'start') return <StartScreen onStart={handleStart} />;
   if (mode === 'sprint' || mode === 'survival')
-    return <GameScreen mode={mode} onFinish={handleFinish} />;
+    return <GameScreen mode={mode} onFinish={handleFinish} onHome={handleHome} />;
   return <EndScreen score={score} onRestart={handleRestart} />;
 }

--- a/frontend/src/components/Map.tsx
+++ b/frontend/src/components/Map.tsx
@@ -1,5 +1,7 @@
 import { MapContainer, TileLayer, Marker, Polyline, useMapEvents } from 'react-leaflet';
 import { LatLngTuple, LeafletMouseEvent } from 'leaflet';
+import L from 'leaflet';
+import { useEffect, useRef } from 'react';
 
 
 interface ClickHandlerProps {
@@ -20,9 +22,28 @@ export interface MapProps {
   correctPoint?: LatLngTuple;
   clickedPoint?: LatLngTuple;
   lineColor?: string;
+  answerCorrect?: boolean;
 }
 
-export default function GameMap({ onMapClick, correctPoint, clickedPoint, lineColor = 'blue' }: MapProps) {
+export default function GameMap({
+  onMapClick,
+  correctPoint,
+  clickedPoint,
+  lineColor = 'blue',
+  answerCorrect,
+}: MapProps) {
+  const clickedRef = useRef<L.Marker>(null);
+
+  useEffect(() => {
+    if (!clickedRef.current || clickedPoint === undefined) return;
+    const el = clickedRef.current.getElement();
+    if (!el) return;
+    const cls = answerCorrect ? 'marker-bounce-correct' : 'marker-bounce-wrong';
+    el.classList.add(cls);
+    const remove = () => el.classList.remove(cls);
+    el.addEventListener('animationend', remove, { once: true });
+  }, [clickedPoint, answerCorrect]);
+
   return (
     <MapContainer center={[20, 0]} zoom={2} style={{ height: '100%', width: '100%' }}>
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
@@ -31,7 +52,7 @@ export default function GameMap({ onMapClick, correctPoint, clickedPoint, lineCo
       {correctPoint && clickedPoint && (
         <>
           <Marker position={correctPoint} />
-          <Marker position={clickedPoint} />
+          <Marker ref={clickedRef} position={clickedPoint} />
           <Polyline pathOptions={{ color: lineColor }} positions={[clickedPoint, correctPoint]} />
 
         </>

--- a/frontend/src/components/StatsModal.tsx
+++ b/frontend/src/components/StatsModal.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+interface Props {
+  correct: boolean;
+  distance: number;
+  score: number;
+  question: number;
+  onContinue: () => void;
+  onHome: () => void;
+}
+
+export default function StatsModal({ correct, distance, score, question, onContinue, onHome }: Props) {
+  const color = distance <= 50 ? 'green' : distance <= 200 ? 'yellow' : 'red';
+  return (
+    <div className="stats-modal">
+      <div className="stats-modal-content">
+        <h2 style={{ color }}>{correct ? 'Correct!' : 'Wrong!'}</h2>
+        <p>Distance: {distance.toFixed(2)} km</p>
+        <p>Score: {score}</p>
+        <p>Question: {question}</p>
+        <div className="stats-buttons">
+          <button onClick={onContinue}>Continue</button>
+          <button onClick={onHome}>Home</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -71,3 +71,80 @@ button:hover {
   padding: 0.5rem;
 }
 
+/* marker animations */
+@keyframes bounce {
+  0% {
+    transform: translateY(0);
+  }
+  30% {
+    transform: translateY(-15px);
+  }
+  60% {
+    transform: translateY(0);
+  }
+  80% {
+    transform: translateY(-7px);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+
+@keyframes shake {
+  0% {
+    transform: translateX(0);
+  }
+  20% {
+    transform: translateX(-5px);
+  }
+  40% {
+    transform: translateX(5px);
+  }
+  60% {
+    transform: translateX(-5px);
+  }
+  80% {
+    transform: translateX(5px);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+.marker-bounce-correct {
+  animation: bounce 0.6s ease-out;
+}
+
+.marker-bounce-wrong {
+  animation: shake 0.5s ease-out;
+}
+
+
+.stats-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.stats-modal-content {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: 8px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.stats-buttons {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}


### PR DESCRIPTION
## Summary
- implement `StatsModal` component to show results
- pause timers and remove auto-advance in `GameScreen`
- allow returning home from `GameScreen` via `App`
- style modal overlay

## Testing
- `npm test` in `backend`
- `npm run build` in `frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883b65c161c8329bec89440ad4ff5e7