### PR TITLE
Add question timer with animation

### DIFF
--- a/frontend/src/components/QuestionTimer.tsx
+++ b/frontend/src/components/QuestionTimer.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useState } from 'react';
+
+interface Props {
+  seconds: number;
+  onExpire: () => void;
+}
+
+export default function QuestionTimer({ seconds, onExpire }: Props) {
+  const [time, setTime] = useState(seconds);
+  const [expired, setExpired] = useState(false);
+
+  useEffect(() => {
+    setTime(seconds);
+    setExpired(false);
+  }, [seconds]);
+
+  useEffect(() => {
+    if (time <= 0) {
+      if (!expired) onExpire();
+      setExpired(true);
+      return;
+    }
+    const id = setTimeout(() => setTime(t => t - 1), 1000);
+    return () => clearTimeout(id);
+  }, [time, onExpire, expired]);
+
+  const progress = (time / seconds) * 100;
+
+  return (
+    <div className={`question-timer${expired ? ' time-up' : ''}`}> 
+      <div className="progress-bar" style={{ width: `${progress}%` }} />
+      <span className="timer-label">{time}</span>
+    </div>
+  );
+}

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -3,6 +3,7 @@ import GameMap from '../components/Map';
 import QuestionBox from '../components/QuestionBox';
 import StrikeCounter from '../components/StrikeCounter';
 import GameTimer from '../components/GameTimer';
+import QuestionTimer from '../components/QuestionTimer';
 import StatsModal from '../components/StatsModal';
 
 import { Question, AnswerResponse } from '../types';
@@ -121,7 +122,7 @@ export default function GameScreen({ mode, onFinish, onHome }: Props) {
       {question && <QuestionBox text={question.text} hint={question.hint} />}
       <StrikeCounter strike={strike} />
       <div className="timers">
-        <GameTimer seconds={qTime} onExpire={() => {}} />
+        <QuestionTimer seconds={qTime} onExpire={() => {}} />
         {mode === 'sprint' && <GameTimer seconds={gameTime} onExpire={() => {}} />}
       </div>
       <div className="map-container">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -55,6 +55,45 @@ button:hover {
   border-radius: 4px;
 }
 
+.question-timer {
+  position: relative;
+  width: 200px;
+  height: 24px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background: #eee;
+  overflow: hidden;
+}
+
+.question-timer .progress-bar {
+  height: 100%;
+  background: linear-gradient(to right, #4caf50, #f1c40f);
+  transition: width 1s linear;
+}
+
+.question-timer.time-up .progress-bar {
+  background: #e74c3c;
+  animation: flash 0.5s step-end infinite;
+}
+
+.question-timer .timer-label {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+@keyframes flash {
+  50% {
+    opacity: 0;
+  }
+}
+
 .result-overlay {
   position: absolute;
   top: 10px;


### PR DESCRIPTION
## Summary
- add a `QuestionTimer` React component with progress bar
- style the question timer and flashing animation when time is up
- use `QuestionTimer` on `GameScreen`

## Testing
- `cd backend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886736b5d0483299f290d363a5f12bd