### PR TITLE
Add topic selection option

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Category } from './types';
 import StartScreen from './screens/StartScreen';
 import GameScreen from './screens/GameScreen';
 import EndScreen from './screens/EndScreen';
@@ -6,8 +7,10 @@ import EndScreen from './screens/EndScreen';
 export default function App() {
   const [mode, setMode] = useState<'start' | 'sprint' | 'survival' | 'end'>('start');
   const [score, setScore] = useState(0);
+  const [category, setCategory] = useState<Category>('landmark');
 
-  const handleStart = (m: 'sprint' | 'survival') => {
+  const handleStart = (m: 'sprint' | 'survival', c: Category) => {
+    setCategory(c);
     setMode(m);
   };
 
@@ -27,6 +30,13 @@ export default function App() {
 
   if (mode === 'start') return <StartScreen onStart={handleStart} />;
   if (mode === 'sprint' || mode === 'survival')
-    return <GameScreen mode={mode} onFinish={handleFinish} onHome={handleHome} />;
+    return (
+      <GameScreen
+        mode={mode}
+        category={category}
+        onFinish={handleFinish}
+        onHome={handleHome}
+      />
+    );
   return <EndScreen score={score} onRestart={handleRestart} />;
 }

--- a/frontend/src/screens/GameScreen.tsx
+++ b/frontend/src/screens/GameScreen.tsx
@@ -5,7 +5,7 @@ import StrikeCounter from '../components/StrikeCounter';
 import GameTimer from '../components/GameTimer';
 import StatsModal from '../components/StatsModal';
 
-import { Question, AnswerResponse } from '../types';
+import { Question, AnswerResponse, Category } from '../types';
 
 function calculatePoints(distanceKm: number): number {
   if (distanceKm <= 200) return 1000;
@@ -17,11 +17,12 @@ function calculatePoints(distanceKm: number): number {
 }
 interface Props {
   mode: 'sprint' | 'survival';
+  category: Category;
   onFinish: (score: number) => void;
   onHome: () => void;
 }
 
-export default function GameScreen({ mode, onFinish, onHome }: Props) {
+export default function GameScreen({ mode, category, onFinish, onHome }: Props) {
   const [question, setQuestion] = useState<Question | null>(null);
   const [clicked, setClicked] = useState<[number, number] | null>(null);
   const [result, setResult] = useState<AnswerResponse | null>(null);
@@ -32,7 +33,12 @@ export default function GameScreen({ mode, onFinish, onHome }: Props) {
   const [gameTime, setGameTime] = useState(mode === 'sprint' ? 120 : 0);
 
   const fetchQuestion = () => {
-    fetch('http://localhost:3000/questions?category=landmark')
+    let cat: Category = category;
+    if (category === 'mixed') {
+      const all: Category[] = ['landmark', 'capital', 'country'];
+      cat = all[Math.floor(Math.random() * all.length)];
+    }
+    fetch(`http://localhost:3000/questions?category=${cat}`)
       .then(r => r.json())
       .then((q: Question) => {
         setQuestion(q);
@@ -44,7 +50,7 @@ export default function GameScreen({ mode, onFinish, onHome }: Props) {
 
   useEffect(() => {
     fetchQuestion();
-  }, []);
+  }, [category]);
 
   useEffect(() => {
     if (mode === 'sprint') {

--- a/frontend/src/screens/StartScreen.tsx
+++ b/frontend/src/screens/StartScreen.tsx
@@ -1,13 +1,27 @@
+import { useState } from 'react';
+import { Category } from '../types';
+
 interface Props {
-  onStart: (mode: 'sprint' | 'survival') => void;
+  onStart: (mode: 'sprint' | 'survival', category: Category) => void;
 }
 
 export default function StartScreen({ onStart }: Props) {
+  const [category, setCategory] = useState<Category>('landmark');
+
   return (
     <div className="start-screen">
       <h1>Игра GeoGuess</h1>
-      <button onClick={() => onStart('sprint')}>Спринт</button>
-      <button onClick={() => onStart('survival')}>Выживание</button>
+      <select
+        value={category}
+        onChange={e => setCategory(e.target.value as Category)}
+      >
+        <option value="landmark">Достопримечательности</option>
+        <option value="capital">Столицы</option>
+        <option value="country">Страны</option>
+        <option value="mixed">Смешанная</option>
+      </select>
+      <button onClick={() => onStart('sprint', category)}>Спринт</button>
+      <button onClick={() => onStart('survival', category)}>Выживание</button>
     </div>
   );
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,3 +1,5 @@
+export type Category = 'country' | 'capital' | 'landmark' | 'mixed';
+
 export type Question = {
   id: number;
   text: string;


### PR DESCRIPTION
## Summary
- allow choosing question category on the start screen
- propagate selected category to the game screen
- fetch questions from selected category or random category if mixed

## Testing
- `npm test` in `backend`
- `npm run build` in `frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886780df93083299f37589ee790acb1