### PR TITLE
Improve answer logic for countries and cities

### DIFF
--- a/backend/src/questions.ts
+++ b/backend/src/questions.ts
@@ -88,6 +88,7 @@ export const questions: Question[] = [
     lng: 37.6176,
     hint: 'Столица России',
     category: 'capital',
+    radiusKm: 50,
   },
   {
     id: 12,
@@ -96,6 +97,7 @@ export const questions: Question[] = [
     lng: 13.4050,
     hint: 'Столица Германии',
     category: 'capital',
+    radiusKm: 50,
   },
   {
     id: 13,
@@ -104,6 +106,7 @@ export const questions: Question[] = [
     lng: 139.6917,
     hint: 'Столица Японии',
     category: 'capital',
+    radiusKm: 50,
   },
   {
     id: 14,
@@ -112,6 +115,7 @@ export const questions: Question[] = [
     lng: 149.13,
     hint: 'Столица Австралии',
     category: 'capital',
+    radiusKm: 50,
   },
   {
     id: 15,
@@ -120,6 +124,7 @@ export const questions: Question[] = [
     lng: -75.6972,
     hint: 'Столица Канады',
     category: 'capital',
+    radiusKm: 50,
   },
   {
     id: 16,
@@ -128,6 +133,7 @@ export const questions: Question[] = [
     lng: 2.2137,
     hint: 'Западноевропейская страна',
     category: 'country',
+    bbox: [41, -5.5, 51.5, 9.5],
   },
   {
     id: 17,
@@ -136,6 +142,7 @@ export const questions: Question[] = [
     lng: -51.9253,
     hint: 'Крупнейшая страна Южной Америки',
     category: 'country',
+    bbox: [-34, -74, 5, -34],
   },
   {
     id: 18,
@@ -144,6 +151,7 @@ export const questions: Question[] = [
     lng: 30.8025,
     hint: 'Страна на северо-востоке Африки',
     category: 'country',
+    bbox: [22, 24, 32, 36],
   },
   {
     id: 19,
@@ -152,6 +160,7 @@ export const questions: Question[] = [
     lng: 78.9629,
     hint: 'Южноазиатская страна',
     category: 'country',
+    bbox: [6, 68, 36, 97],
   },
   {
     id: 20,
@@ -160,5 +169,6 @@ export const questions: Question[] = [
     lng: -106.3468,
     hint: 'Вторая по величине страна мира',
     category: 'country',
+    bbox: [41, -141, 83, -52],
   },
 ];

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -52,7 +52,19 @@ function handleCheckAnswer(req: any, res: any) {
       question.lat,
       question.lng
     );
-    const correct = distance <= 200;
+
+    let correct = false;
+    if (question.bbox) {
+      const [minLat, minLng, maxLat, maxLng] = question.bbox;
+      correct =
+        data.clickedLat >= minLat &&
+        data.clickedLat <= maxLat &&
+        data.clickedLng >= minLng &&
+        data.clickedLng <= maxLng;
+    } else {
+      const radius = question.radiusKm ?? 200;
+      correct = distance <= radius;
+    }
     const prevStrike = sessionStrikes[data.sessionId] || 0;
     const strike = correct ? prevStrike + 1 : 0;
     sessionStrikes[data.sessionId] = strike;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -1,3 +1,5 @@
+export type BBox = [number, number, number, number];
+
 export type Question = {
   id: number;
   text: string;
@@ -5,6 +7,10 @@ export type Question = {
   lng: number;
   hint: string;
   category: 'country' | 'capital' | 'landmark';
+  /** Optional bounding box for countries */
+  bbox?: BBox;
+  /** Optional radius in km for cities/landmarks */
+  radiusKm?: number;
 };
 
 export type AnswerRequest = {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,7 @@
 export type Category = 'country' | 'capital' | 'landmark' | 'mixed';
 
+export type BBox = [number, number, number, number];
+
 export type Question = {
   id: number;
   text: string;
@@ -7,6 +9,8 @@ export type Question = {
   lng: number;
   hint: string;
   category: 'country' | 'capital' | 'landmark';
+  bbox?: BBox;
+  radiusKm?: number;
 };
 
 export type AnswerResponse = {


### PR DESCRIPTION
## Summary
- extend question schema with optional `bbox` and `radiusKm`
- include radius for capital cities and bounding boxes for countries
- check clicked coordinates against bounding box or radius on the backend
- sync updated question type with the frontend

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886863563f88329afd38bbef42d84fa